### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/BlazorUI.yml
+++ b/.github/workflows/BlazorUI.yml
@@ -13,6 +13,8 @@ jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/TralaAI/Blazor/security/code-scanning/1](https://github.com/TralaAI/Blazor/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `build` job. Since the job only requires read access to the repository contents (e.g., for checking out code), we will set `contents: read` as the permission. This ensures that the job adheres to the principle of least privilege.

The changes will be made in the `.github/workflows/BlazorUI.yml` file, specifically within the `build` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
