### PR TITLE
Refactor MainLayout.razor for improved layout structure and styling

### DIFF
--- a/Components/Layout/MainLayout.razor
+++ b/Components/Layout/MainLayout.razor
@@ -5,22 +5,16 @@
         <NavMenu />
     </div>
 
-    <main>
+    <main style="overflow-y: auto; height: 100vh;">
         <div class="top-row px-4 status-bar">
-    <div class="status-left">
-        <strong>Laatste update:</strong> @lastUpdated?.ToString()
-    </div>
+            <div class="status-left">
+                <strong>Laatste update:</strong> @lastUpdated?.ToString()
+            </div>
 
-    @* <div class="status-center">
-        <span class="api-status" style="color:@(pythonStatus ? "limegreen" : "red")">Python API</span>
-        <span class="api-status" style="color:@(dotnetStatus ? "limegreen" : "red")">.NET API</span>
-        <span class="api-status" style="color:@(holidayStatus ? "limegreen" : "red")">Holiday API</span>
-    </div> *@
-
-    <div class="status-right">
-        <button class="refresh-button" @onclick="SimuleerStatusUpdate">Settings</button>
-    </div>
-</div>
+            <div class="status-right">
+                <button class="refresh-button" @onclick="SimuleerStatusUpdate">Settings</button>
+            </div>
+        </div>
 
         <article class="content px-4">
             @Body


### PR DESCRIPTION
This pull request makes a small but impactful change to the `MainLayout.razor` file to enhance the user interface and remove unused code.

UI improvement:

* Updated the `<main>` element to include `style="overflow-y: auto; height: 100vh;"`, ensuring the main content area scrolls properly and occupies the full viewport height.

Code cleanup:

* Removed commented-out code related to API status indicators (`Python API`, `.NET API`, and `Holiday API`), as it is no longer in use.